### PR TITLE
fix: watermarked videos now include audio

### DIFF
--- a/scripts/watermark.py
+++ b/scripts/watermark.py
@@ -22,6 +22,9 @@ def add_watermark(input_video_path, watermark_url, output_video_path):
     # Write the video clip to a file
     video_with_watermark.write_videofile(output_video_path)
 
+    # Add the original audio to the final output
+    video_with_watermark = video_with_watermark.set_audio(clip.audio)
+
     # Close the clips to free up memory
     clip.close()
     video_with_watermark.close()
@@ -36,6 +39,5 @@ def download_img(url):
             file.write(response.content)
         return os.path.abspath(filename)
     else:
-        print(
-            f"Failed to download the image, status code: {response.status_code}")
-        return None
+        print(f"Failed to download the image, status code: {response.status_code}")
+        raise Exception(f"Failed to download the image, status code: {response.status_code}")

--- a/scripts/watermark.py
+++ b/scripts/watermark.py
@@ -19,16 +19,14 @@ def add_watermark(input_video_path, watermark_url, output_video_path):
     video_with_watermark = CompositeVideoClip(
         [clip, watermark.set_position(position)])
 
-    # Write the video clip to a file
-    video_with_watermark.write_videofile(output_video_path)
-
     # Add the original audio to the final output
     video_with_watermark = video_with_watermark.set_audio(clip.audio)
 
+    # Write the video clip to a file
+    video_with_watermark.write_videofile(output_video_path, codec="libx264", audio_codec="aac")
     # Close the clips to free up memory
     clip.close()
     video_with_watermark.close()
-
 
 def download_img(url):
     response = requests.get(url)

--- a/scripts/watermark.py
+++ b/scripts/watermark.py
@@ -34,7 +34,7 @@ def download_img(url):
     response = requests.get(url)
 
     if response.status_code == 200:
-        filename = "watermark.png"
+        filename = "output/watermark.png"
         with open(filename, "wb") as file:
             file.write(response.content)
         return os.path.abspath(filename)


### PR DESCRIPTION
This PR resolves an issue where the audio was being removed from the output video when a watermark was added. The fix ensures that the original audio is included in the final watermarked video.

Changes:

- Added a line to set the audio of the video_with_watermark object to the original clip's audio
- Changed the watermark file saving location to the "output" folder and updated the path in the download_img function accordingly.
- In the download_img function, replaced the print statement with an exception to raise an error if the image download fails.
With these changes, users can now add watermarks to their videos without losing the original audio.

🤖 