### PR TITLE
Demo Video using default settings on PR create

### DIFF
--- a/.github/workflows/demo_video.yml
+++ b/.github/workflows/demo_video.yml
@@ -1,0 +1,53 @@
+name: Generate Video
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  generate_video:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+
+      - name: Move video_script.yml to input directory
+        run: mv ./lib/video_script.yml input/
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Generate video
+        run: python scripts/main.py -d
+
+      - name: Show summary
+        run: |
+          echo "### Sample Video 📺 Created with script 📜: " >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          cat input/sample_script.yml >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+        shell: bash
+
+      - name: Upload video artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: final-video
+          path: output/final.mp4
+
+      - name: Post comment on pull request
+        uses: unsplash/comment-on-pr@v1.3.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          check_for_duplicate_msg: false
+          msg: |
+            Video generated. [Download here](https://github.com/${{ github.repository }}/actions/artifacts/${{ github.run_id }}/download).

--- a/lib/video_script.yml
+++ b/lib/video_script.yml
@@ -1,0 +1,8 @@
+title: Simple Video Example
+timeline:
+  - content: "Welcome to our video! This is the first scene with an AI-generated voice."
+    clip: "https://www.pexels.com/download/video/6394054/"
+  - content: "Now, we're moving to the second scene. Enjoy the visuals!"
+    clip: "https://www.pexels.com/download/video/2034291/"
+  - content: "That's it for our video. Thanks for watching and stay tuned for more content!"
+    clip: "https://www.pexels.com/download/video/3150358/?fps=25.0&h=1080&w=2048"

--- a/scripts/narration.py
+++ b/scripts/narration.py
@@ -9,6 +9,7 @@ def create_narration(input_script, options, output_dir):
     if cfg.debug:
         output_path = output_dir + "/narration.mpeg"
         shutil.copy("lib/voice-sample.mpeg", output_path)
+        return output_path
 
 
     engine = options["engine"]


### PR DESCRIPTION
When creating a PR, run a GH action that will generate a video using the sample script and comment on the PR.
We could have this run on every push to a PR it depends whether we use debug mode.

It seems we no longer use debug mode in the app. I would like to add another commit that stores sample narration audio files so we don't need to get them every time but want to discuss further. Maybe the first time it is run on a PR it creates audio files that are re-used for pushes on that PR.

![image](https://user-images.githubusercontent.com/17269242/230648917-ec2b797b-39f0-4a33-b0d4-64258b52af30.png)

BEFORE MERGING - decide if we want to use google creds on every push to a PR.
Want feedback from @fitzhavey before doing more.

todo:
something like this based on https://github.com/unsplash/comment-on-pr
```
  uses: unsplash/comment-on-pr@v1.3.0
        env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
        with:
          msg: "Check out this error message!"
          delete_prev_regex_msg: ${{ contains( env.msg, 'error' ) && '[0-9]' || '' }}
```

we are also not adding the cli arg for the path in this. needs to be done.