### PR TITLE
feat: support global engine setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,13 @@ Here is a simple example script that can be passed as an input to the app:
 ```yaml
 title: Simple Video Example
 watermark: "https://i.imgur.com/NbzMg2q.png" # Optional
+engine: "eleven" # One of ["eleven", "google"]. Default is "google"
 captions: True # Optional
 timeline:
   - content: "Welcome to our video! This is the first scene with an AI-generated voice."
     clip: "https://www.pexels.com/download/video/6394054/"
   - content: "Now, we're moving to the second scene. Enjoy the visuals!"
-    engine: "eleven" # One of ["eleven", "google"]. Default is "google"
+    engine: "google" # global engine can be overridden for individual timeline items
     clip: "https://www.pexels.com/download/video/2034291/"
   - content: "That's it for our video. Thanks for watching and stay tuned for more content!"
     clip: "https://www.pexels.com/download/video/3150358/?fps=25.0&h=1080&w=2048"

--- a/scripts/video_generator.py
+++ b/scripts/video_generator.py
@@ -8,13 +8,15 @@ def generate():
     with open("input/video_script.yml", "r") as file:
         video_script = yaml.safe_load(file)
 
+    global_engine = video_script.get("engine", "google")
+
     # Iterate through the timeline of content items and stock video clips to create video segments
     for index, item in enumerate(video_script["timeline"]):
         content = item["content"]
         clip_url = item["clip"]
 
         narration_options = {
-            "engine": item.get("engine", "google")
+            "engine": item.get("engine", global_engine),
         }
         video_options = {
             "captions": video_script.get("captions", False),


### PR DESCRIPTION
`engine` field can now be set on the top level of the script, to set the tts engine for the entire script