### PR TITLE
fix: audio artifacts when combining clips

### DIFF
--- a/scripts/video_generator.py
+++ b/scripts/video_generator.py
@@ -32,6 +32,7 @@ def generate():
         print("> Compiling video segment...")
         create_segment(audio_file_path, clip_url, content, video_options, output_dir)
 
-    # Stitch the video segments together
+    print("> Concatenating video segments...")
     segment_paths = [os.path.join("output", str(index), "video_processed.mp4") for index, item in enumerate(video_script["timeline"])]
     concatenate_segments(segment_paths, "output/final.mp4")
+    print("> Done")


### PR DESCRIPTION
Previously we would get weird audio artifacts when concatenating video clips, (see https://www.youtube.com/watch?v=v9vWjE_xDkw, 10s in). 

## New Output: 
https://user-images.githubusercontent.com/2746248/230875154-4d189b2f-df22-43fb-b731-dd50458047c2.mp4

It's a known bug due to how MoviePy handles mp4s:
- https://www.reddit.com/r/moviepy/comments/jiyp23/adding_audio_to_clips_concat_creates_audio/
- https://github.com/Zulko/moviepy/issues/1936

Another upside to this change is that the final step is now a lot faster!
_I did have to run `brew install ffmpeg` again to get it to work for some reason though 🤔_