### PR TITLE
feat: support voice customisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Here is a simple example script that can be passed as an input to the app:
 title: Simple Video Example
 watermark: "https://i.imgur.com/NbzMg2q.png" # Optional
 engine: "eleven" # One of ["eleven", "google"]. Default is "google"
+engine_settings: # optional per engine settings, check the code in scripts/tts_engines/... for specifics & defaults
+  voice_id: "ErXwobaYiN019PkySvjV"
 captions: True # Optional
 timeline:
   - content: "Welcome to our video! This is the first scene with an AI-generated voice."

--- a/scripts/narration.py
+++ b/scripts/narration.py
@@ -10,11 +10,11 @@ def create_narration(input_script, options, output_dir):
         output_path = output_dir + "/narration.mpeg"
         shutil.copy("lib/voice-sample.mpeg", output_path)
 
-
     engine = options["engine"]
+    settings = options["engine_settings"]
     if engine == "google":
-        return narrate_google(input_script, output_dir)
+        return narrate_google(input_script, output_dir, settings)
     elif engine == "eleven":
-        return narrate_eleven(input_script, output_dir)
+        return narrate_eleven(input_script, output_dir, settings)
     else:
         raise Exception("Unknown engine: " + engine)

--- a/scripts/tts_engines/eleven_labs.py
+++ b/scripts/tts_engines/eleven_labs.py
@@ -2,16 +2,13 @@ import requests
 from config import Config
 cfg = Config()
 
-def narrate(input_script, output_dir):
-    output_path = output_dir + "/narration.mpeg"
+def narrate(input_script, output_dir, settings):
+    voice_id = settings.get("voice_id", "TxGEqnHWrfWFTfGW9XjX")
 
     tts_headers = {
         "Content-Type": "application/json",
         "xi-api-key": cfg.elevenlabs_api_key
     }
-
-    # TODO: extract below settings and expose in script yaml
-    voice_id = "ErXwobaYiN019PkySvjV"
     tts_url = f"https://api.elevenlabs.io/v1/text-to-speech/{voice_id}"
 
     # TODO: fix issue where we seem to need to clip off script at 333 characters
@@ -21,6 +18,7 @@ def narrate(input_script, output_dir):
     )
 
     if response.status_code == 200:
+        output_path = output_dir + "/narration.mpeg"
         with open(output_path, "wb") as f:
             f.write(response.content)
         return output_path

--- a/scripts/tts_engines/google_tts.py
+++ b/scripts/tts_engines/google_tts.py
@@ -1,25 +1,24 @@
 from google.cloud import texttospeech
 
-def narrate(input_script, output_dir):
-    output_path = output_dir + "/narration.mp3"
+def narrate(input_script, output_dir, settings):
+    language_code = settings.get("language_code", "en-UK")
+    ssml_gender_string = settings.get("ssml_gender", "NEUTRAL")
+    ssml_gender = texttospeech.SsmlVoiceGender[ssml_gender_string]
 
     client = texttospeech.TextToSpeechClient()
-
     synthesis_input = texttospeech.SynthesisInput(text=input_script)
-
-    # TODO: extract below settings and expose in script yaml
     voice = texttospeech.VoiceSelectionParams(
-        language_code="en-UK", ssml_gender=texttospeech.SsmlVoiceGender.NEUTRAL
+        language_code=language_code,
+        ssml_gender=ssml_gender
     )
-
     audio_config = texttospeech.AudioConfig(
         audio_encoding=texttospeech.AudioEncoding.MP3
     )
-
     response = client.synthesize_speech(
         input=synthesis_input, voice=voice, audio_config=audio_config
     )
 
+    output_path = output_dir + "/narration.mp3"
     with open(output_path, "wb") as out:
         out.write(response.audio_content)
 

--- a/scripts/video_generator.py
+++ b/scripts/video_generator.py
@@ -9,6 +9,7 @@ def generate():
         video_script = yaml.safe_load(file)
 
     global_engine = video_script.get("engine", "google")
+    global_engine_settings = video_script.get("engine_settings", {})
 
     # Iterate through the timeline of content items and stock video clips to create video segments
     for index, item in enumerate(video_script["timeline"]):
@@ -18,6 +19,7 @@ def generate():
 
         narration_options = {
             "engine": item.get("engine", global_engine),
+            "engine_settings": item.get("engine_settings", global_engine_settings)
         }
         video_options = {
             "captions": video_script.get("captions", False),


### PR DESCRIPTION
Adds the optional field `engine_settings` to the input YAML. It can be set globally at the top level or on individual timeline entries.

This allows us to customise the voice used. For Google that means:
- set region
- set gender

For Eleven Labs that means:
- set voice id
    _Voice ID will have to either be global or one linked to account associated with the API key_