### PR TITLE
fix: remove 333 char limit for eleven voice generation

### DIFF
--- a/scripts/tts_engines/eleven_labs.py
+++ b/scripts/tts_engines/eleven_labs.py
@@ -11,8 +11,6 @@ def narrate(input_script, output_dir, settings):
     }
     tts_url = f"https://api.elevenlabs.io/v1/text-to-speech/{voice_id}"
 
-    # TODO: fix issue where we seem to need to clip off script at 333 characters
-    # formatted_message = {"text": input_script[:333]}
     formatted_message = {"text": input_script}
     response = requests.post(
         tts_url, headers=tts_headers, json=formatted_message

--- a/scripts/tts_engines/eleven_labs.py
+++ b/scripts/tts_engines/eleven_labs.py
@@ -12,7 +12,8 @@ def narrate(input_script, output_dir, settings):
     tts_url = f"https://api.elevenlabs.io/v1/text-to-speech/{voice_id}"
 
     # TODO: fix issue where we seem to need to clip off script at 333 characters
-    formatted_message = {"text": input_script[:333]}
+    # formatted_message = {"text": input_script[:333]}
+    formatted_message = {"text": input_script}
     response = requests.post(
         tts_url, headers=tts_headers, json=formatted_message
     )


### PR DESCRIPTION
It seems this issue no longer applies, see wiki:
https://www.notion.so/innovation-squad/confirm-333-character-limit-on-eleven-voice-generation-is-an-issue-and-if-so-fix-or-document-it-69cc8181e6c14e3290dcd924665c4de3